### PR TITLE
Added logic to filter Active/Inactive concepts

### DIFF
--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/utility/CommonSearchFilterUtils.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/utility/CommonSearchFilterUtils.java
@@ -26,6 +26,7 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Extensions.Generic.MappingExtension;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
+import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.ActiveOption;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.codingSchemes.CodingScheme;
 import org.LexGrid.valueSets.ValueSetDefinition;
@@ -261,11 +262,40 @@ public final class CommonSearchFilterUtils {
 					lexCodedNodeSet = CommonSearchFilterUtils.filterLexCodedNodeSet(lexCodedNodeSet, cts2Filter);
 				}
 			}
+			
+			lexCodedNodeSet = CommonSearchFilterUtils.filterLexCodedNodeSet(lexCodedNodeSet, queryData.getReadContext());
 		}
 		
 		return lexCodedNodeSet;
 	}
 	
+	private static CodedNodeSet filterLexCodedNodeSet(
+			CodedNodeSet lexCodedNodeSet, ResolvedReadContext readContext) {
+		if(readContext != null) {
+			if(readContext.getActive() != null) {
+				ActiveOption activeOption;
+				switch(readContext.getActive()) {
+				case ACTIVE_AND_INACTIVE:
+					activeOption = ActiveOption.ALL;
+					break;
+				case ACTIVE_ONLY:
+					activeOption = ActiveOption.ACTIVE_ONLY;
+					break;
+				default:
+					throw new IllegalStateException("Illegal Active Option: " + readContext.getActive());
+				}
+				
+				try {
+					lexCodedNodeSet = lexCodedNodeSet.restrictToStatus(activeOption, null);
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				} 
+			}
+		}
+		
+		return lexCodedNodeSet;
+	}
+
 	public static CodedNodeSet filterLexCodedNodeSet(
 			CodedNodeSet lexCodedNodeSet,
 			ResolvedFilter cts2Filter){

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/utility/QueryData.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/utility/QueryData.java
@@ -236,6 +236,7 @@ public final class QueryData <Query extends ResourceQuery>{
 		EntityDescriptionQueryServiceRestrictions localCts2Restrictions = cts2Query.getRestrictions();
 		this.cts2Restrictions = localCts2Restrictions;
 		this.cts2Filters = cts2Query.getFilterComponent();
+		this.readContext = cts2Query.getReadContext();
 				
 		// Not needed?
 //		query.getEntitiesFromAssociationsQuery();

--- a/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/entity/LexEvsEntityQueryServiceTestIT.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/entity/LexEvsEntityQueryServiceTestIT.java
@@ -8,11 +8,9 @@
 */
 package edu.mayo.cts2.framework.plugin.service.lexevs.service.entity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -30,6 +28,7 @@ import edu.mayo.cts2.framework.model.entity.EntityDirectoryEntry;
 import edu.mayo.cts2.framework.model.entity.EntityListEntry;
 import edu.mayo.cts2.framework.model.service.core.NameOrURI;
 import edu.mayo.cts2.framework.model.service.core.Query;
+import edu.mayo.cts2.framework.model.service.core.types.ActiveOrAll;
 import edu.mayo.cts2.framework.model.util.ModelUtils;
 import edu.mayo.cts2.framework.plugin.service.lexevs.test.AbstractQueryServiceTest;
 import edu.mayo.cts2.framework.plugin.service.lexevs.utility.CommonTestUtils;
@@ -217,6 +216,124 @@ public class LexEvsEntityQueryServiceTestIT
 		assertNotNull("Expecting data returned but list is null", list);
 		String msg = "Expecting list.size() > 0, instead list.size() = " + list.size();
 		assertTrue(msg, list.size() > 0);		
+	}	
+	
+	@Test
+	public void testGetResourceSummaries_Filter_OnlyActive() throws Exception {
+				
+		// Create query
+		// ------------
+		EntityDescriptionQuery query = new EntityDescriptionQuery() {
+
+			@Override
+			public Query getQuery() {
+				return null;
+			}
+
+			@Override
+			public Set<ResolvedFilter> getFilterComponent() {
+				return new HashSet<ResolvedFilter>();
+			}
+
+			@Override
+			public ResolvedReadContext getReadContext() {
+				ResolvedReadContext context = new ResolvedReadContext();
+				context.setActive(ActiveOrAll.ACTIVE_ONLY);
+				
+				return context;
+			}
+
+			@Override
+			public EntitiesFromAssociationsQuery getEntitiesFromAssociationsQuery() {
+				return null;
+			}
+
+			@Override
+			public EntityDescriptionQueryServiceRestrictions getRestrictions() {
+				EntityDescriptionQueryServiceRestrictions query = new EntityDescriptionQueryServiceRestrictions();
+				query.getCodeSystemVersions().add(ModelUtils.nameOrUriFromName("Automobiles-1.0"));
+				
+				return query;
+			}
+			
+		};
+				
+		// Call getResourceSummaries from service
+		// --------------------------------------
+		Page page = new Page();
+		DirectoryResult<EntityDirectoryEntry> directoryResult = this.service.getResourceSummaries(query, null, page);
+		assertNotNull("Expecting data returned but instead directoryResult is null", directoryResult);
+
+		// Test results
+		// ------------
+		List<EntityDirectoryEntry> list = directoryResult.getEntries();		
+		assertNotNull("Expecting data returned but list is null", list);
+		assertTrue(list.size() > 0);
+		
+		for(EntityDirectoryEntry entry : list) {
+			assertTrue(! entry.getName().getName().equals("73"));
+		}
+	}	
+	
+	@Test
+	public void testGetResourceSummaries_Filter_ActiveAndInactive() throws Exception {
+				
+		// Create query
+		// ------------
+		EntityDescriptionQuery query = new EntityDescriptionQuery() {
+
+			@Override
+			public Query getQuery() {
+				return null;
+			}
+
+			@Override
+			public Set<ResolvedFilter> getFilterComponent() {
+				return new HashSet<ResolvedFilter>();
+			}
+
+			@Override
+			public ResolvedReadContext getReadContext() {
+				ResolvedReadContext context = new ResolvedReadContext();
+				context.setActive(ActiveOrAll.ACTIVE_AND_INACTIVE);
+				
+				return context;
+			}
+
+			@Override
+			public EntitiesFromAssociationsQuery getEntitiesFromAssociationsQuery() {
+				return null;
+			}
+
+			@Override
+			public EntityDescriptionQueryServiceRestrictions getRestrictions() {
+				EntityDescriptionQueryServiceRestrictions query = new EntityDescriptionQueryServiceRestrictions();
+				query.getCodeSystemVersions().add(ModelUtils.nameOrUriFromName("Automobiles-1.0"));
+				
+				return query;
+			}
+			
+		};
+				
+		// Call getResourceSummaries from service
+		// --------------------------------------
+		Page page = new Page();
+		DirectoryResult<EntityDirectoryEntry> directoryResult = this.service.getResourceSummaries(query, null, page);
+		assertNotNull("Expecting data returned but instead directoryResult is null", directoryResult);
+
+		// Test results
+		// ------------
+		List<EntityDirectoryEntry> list = directoryResult.getEntries();		
+		assertNotNull("Expecting data returned but list is null", list);
+		assertTrue(list.size() > 0);
+		
+		for(EntityDirectoryEntry entry : list) {
+			if(entry.getName().getName().equals("73")) {
+				return;
+			}
+		}
+		
+		fail("Didn't find inactive concept '73'");
 	}	
 
 	@Test


### PR DESCRIPTION
NOTE: The Search Extension service currently doesn't have a mechanism to filter out inactive concepts. This will need to be a change to LexEVS itself most likely.
