### PR TITLE
bugfix/LexEVSCTS2-45: Removed Null value addition to CodeSystemVersion Map 

### DIFF
--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/resolvedvalueset/LexEvsResolvedValueSetResolutionService.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/resolvedvalueset/LexEvsResolvedValueSetResolutionService.java
@@ -274,7 +274,9 @@ ResolvedValueSetResolutionService {
 				ResolvedValueSetResolutionEntityRestrictions restrictions = 
 						query.getResolvedValueSetResolutionEntityRestrictions();
 				
-				entityRestrictions.getCodeSystemVersions().add(restrictions.getCodeSystemVersion());
+				if (restrictions.getCodeSystemVersion() != null)
+					entityRestrictions.getCodeSystemVersions().add(restrictions.getCodeSystemVersion());
+
 				entityRestrictions.setEntities(restrictions.getEntities());
 			}
 		


### PR DESCRIPTION
This is a bug in the code where a null value was being added to the map. Java 1.7 sorts the map for the iterator to traverse on by pushing null items to the back, while Java 1.8 does not do this sorting. Removal of sorting in Java 1.8 exposed this bug in the code where null value is being added and get retrieved by the code.