### PR TITLE
LEXEVSCTS2-53: Upgraded the CTS2 Framework dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.2.0.FINAL</version>
+		<version>1.2.1.FINAL</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.5.0.FINAL</version>
+	<version>1.5.1.FINAL</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>
@@ -654,6 +654,20 @@
 
 		<dependency>
 			<groupId>edu.mayo.cts2.framework</groupId>
+			<artifactId>cts2-core</artifactId>
+			<version>${develpment.framework.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>edu.mayo.cts2.framework</groupId>
+			<artifactId>cts2-model</artifactId>
+			<version>${develpment.framework.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>edu.mayo.cts2.framework</groupId>
 			<artifactId>cts2-plugin-util</artifactId>
 			<version>${develpment.framework.version}</version>
 		</dependency>
@@ -663,6 +677,14 @@
 			<artifactId>cts2-webapp-rest-extensions</artifactId>
 			<version>${develpment.framework.version}</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>edu.mayo.cts2.framework</groupId>
+			<artifactId>cts2-webapp</artifactId>
+			<version>${develpment.framework.version}</version>
+			<classifier>classes</classifier>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/transform/TransformUtils.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/transform/TransformUtils.java
@@ -8,22 +8,6 @@
 */
 package edu.mayo.cts2.framework.plugin.service.lexevs.transform;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.annotation.Resource;
-
-import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
-import org.LexGrid.LexBIG.Exceptions.LBException;
-import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
-import org.LexGrid.LexBIG.Utility.Constructors;
-import org.LexGrid.codingSchemes.CodingScheme;
-import org.LexGrid.commonTypes.Property;
-import org.LexGrid.commonTypes.PropertyQualifier;
-import org.apache.commons.lang.StringUtils;
-import org.lexgrid.valuesets.LexEVSValueSetDefinitionServices;
-import org.springframework.stereotype.Component;
-
 import edu.mayo.cts2.framework.core.url.UrlConstructor;
 import edu.mayo.cts2.framework.model.core.CodeSystemReference;
 import edu.mayo.cts2.framework.model.core.CodeSystemVersionReference;
@@ -43,6 +27,20 @@ import edu.mayo.cts2.framework.plugin.service.lexevs.naming.ValueSetNameTranslat
 import edu.mayo.cts2.framework.plugin.service.lexevs.naming.VersionNameConverter;
 import edu.mayo.cts2.framework.plugin.service.lexevs.uri.UriHandler;
 import edu.mayo.cts2.framework.plugin.service.lexevs.utility.CommonResolvedValueSetUtils;
+import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
+import org.LexGrid.LexBIG.Exceptions.LBException;
+import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
+import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.codingSchemes.CodingScheme;
+import org.LexGrid.commonTypes.Property;
+import org.LexGrid.commonTypes.PropertyQualifier;
+import org.apache.commons.lang.StringUtils;
+import org.lexgrid.valuesets.LexEVSValueSetDefinitionServices;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Common Transformation Utilities.
@@ -288,7 +286,7 @@ public class TransformUtils implements LexEvsChangeEventObserver {
 		uriAndName.setName(resolvedConceptReference.getCode());
 		uriAndName.setNamespace(resolvedConceptReference.getCodeNamespace());
 		uriAndName.setUri(this.uriHandler.getEntityUri(resolvedConceptReference));
-		
+
 		return uriAndName;
 	}
 

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/uri/RestUriResolver.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/uri/RestUriResolver.java
@@ -8,23 +8,22 @@
 */
 package edu.mayo.cts2.framework.plugin.service.lexevs.uri;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
+import clojure.lang.RT;
+import clojure.lang.Var;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import clojure.lang.RT;
-import clojure.lang.Var;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Client service based on an external URI Resolver JSON Service.
  *
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
-@Component
+@Component("restUriResolver")
 public class RestUriResolver implements UriResolver, InitializingBean {
 
 	@Value("${uriResolutionServiceUrl}")

--- a/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/entity/EntityUriResolverTestIT.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/entity/EntityUriResolverTestIT.java
@@ -8,16 +8,17 @@
 */
 package edu.mayo.cts2.framework.plugin.service.lexevs.service.entity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import edu.mayo.cts2.framework.model.core.ScopedEntityName;
+import edu.mayo.cts2.framework.plugin.service.lexevs.test.AbstractTestITBase;
+import org.junit.Test;
+import org.springframework.test.annotation.IfProfileValue;
 
 import javax.annotation.Resource;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-import edu.mayo.cts2.framework.model.core.ScopedEntityName;
-import edu.mayo.cts2.framework.plugin.service.lexevs.test.AbstractTestITBase;
-
+@IfProfileValue(name = "spring.profiles.active", value = "withUriResolver")
 public class EntityUriResolverTestIT extends AbstractTestITBase {
 	
 	@Resource

--- a/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/entity/LexEvsEntityQueryServiceIntegrationTestIT.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/entity/LexEvsEntityQueryServiceIntegrationTestIT.java
@@ -1,0 +1,57 @@
+package edu.mayo.cts2.framework.plugin.service.lexevs.service.entity;
+
+import edu.mayo.cts2.framework.core.config.ServerContext;
+import edu.mayo.cts2.framework.core.config.TestServerContext;
+import edu.mayo.cts2.framework.model.command.ResolvedReadContext;
+import edu.mayo.cts2.framework.model.entity.EntityDescriptionMsg;
+import edu.mayo.cts2.framework.model.util.ModelUtils;
+import edu.mayo.cts2.framework.plugin.service.lexevs.test.AbstractTestITBase;
+import edu.mayo.cts2.framework.service.profile.codesystemversion.CodeSystemVersionReadService;
+import edu.mayo.cts2.framework.webapp.naming.CodeSystemVersionNameResolver;
+import edu.mayo.cts2.framework.webapp.rest.command.RestReadContext;
+import edu.mayo.cts2.framework.webapp.rest.controller.EntityDescriptionController;
+import org.LexGrid.LexBIG.test.LexEvsTestRunner;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+
+@LexEvsTestRunner.LoadContent(contentPath="lexevs/test-content/Automobiles.xml")
+public class LexEvsEntityQueryServiceIntegrationTestIT extends AbstractTestITBase {
+
+    @Resource
+    private LexEvsEntityReadService lexEvsEntityReadService;
+
+    @Test
+    public void testGetEntityWithColon(){
+        EntityDescriptionController controller = new EntityDescriptionController() {
+            {
+                ServerContext context = new TestServerContext();
+
+                super.setServerContext(context);
+            }
+        };
+
+        CodeSystemVersionNameResolver resolver = Mockito.mock(CodeSystemVersionNameResolver.class);
+        Mockito.when(resolver.getCodeSystemVersionNameFromVersionId(
+                any(CodeSystemVersionReadService.class),
+                anyString(),
+                anyString(),
+                any(ResolvedReadContext.class))).thenReturn("Automobiles-1.0");
+
+        controller.setCodeSystemVersionNameResolver(resolver);
+        controller.setEntityDescriptionReadService(this.lexEvsEntityReadService);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        ResponseEntity<EntityDescriptionMsg> result = (ResponseEntity) controller.getEntityDescriptionOfCodeSystemVersionByName(request, new RestReadContext(), "Automobiles", "Automobiles-1.0", "Has%3AColon");
+
+        assertEquals("Has:Colon", ModelUtils.getEntity(result.getBody().getEntityDescription()).getEntityID().getName());
+    }
+
+}

--- a/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/uri/RestUriResolverTest.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/uri/RestUriResolverTest.java
@@ -13,11 +13,16 @@ import org.LexGrid.LexBIG.test.BaseContentLoadingInMemoryTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration("/test-lexevs-context.xml")
+@IfProfileValue(name = "spring.profiles.active", value = "withUriResolver")
 public class RestUriResolverTest extends BaseContentLoadingInMemoryTest {
 
 	RestUriResolver resolver;

--- a/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/uri/TestRestUriResolver.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugin/service/lexevs/uri/TestRestUriResolver.java
@@ -1,0 +1,37 @@
+package edu.mayo.cts2.framework.plugin.service.lexevs.uri;
+
+import java.util.Set;
+
+public class TestRestUriResolver implements UriResolver {
+
+    @Override
+    public String idToUri(String id, IdType idType) {
+        return null;
+    }
+
+    @Override
+    public Set<String> idToIds(String id) {
+        return null;
+    }
+
+    @Override
+    public String idToName(String id, IdType idType) {
+        return null;
+    }
+
+    @Override
+    public String idToBaseUri(String id) {
+        return null;
+    }
+
+    @Override
+    public String idAndVersionToVersionUri(String id, String versionId, IdType itType) {
+        return null;
+    }
+
+    @Override
+    public String idAndVersionToVersionName(String id, String versionId, IdType itType) {
+        return null;
+    }
+
+}

--- a/src/test/resources/lexevs/test-content/Automobiles.xml
+++ b/src/test/resources/lexevs/test-content/Automobiles.xml
@@ -261,8 +261,16 @@
       <lgCon:presentation propertyName="textualPresentation" propertyId="p1" isPreferred="true">
         <lgCommon:value>Third Code in cycle</lgCommon:value>
       </lgCon:presentation>
-    </lgCon:entity>  
-    
+    </lgCon:entity>
+
+    <lgCon:entity entityCode="Has:Colon" entityCodeNamespace="Automobiles" isActive="true">
+      <lgCommon:entityDescription>Has Colon</lgCommon:entityDescription>
+      <lgCon:entityType>concept</lgCon:entityType>
+      <lgCon:presentation propertyName="textualPresentation" propertyId="p1" isPreferred="true">
+        <lgCommon:value>Has Colon</lgCommon:value>
+      </lgCon:presentation>
+    </lgCon:entity>
+
     <lgCon:associationEntity entityCode="AssocEntity" entityCodeNamespace="Automobiles"
     	forwardName="GoingForward" reverseName="GoingBackward" isTransitive="true" isNavigable="true">
     	<lgCommon:entityDescription>An AssociationEntity</lgCommon:entityDescription>

--- a/src/test/resources/test-lexevs-context.xml
+++ b/src/test/resources/test-lexevs-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<context:component-scan base-package="edu.mayo.cts2.framework.plugin.service.lexevs" />
 	
@@ -31,5 +31,9 @@
 		class="edu.mayo.cts2.framework.core.config.TestConfigInitializerSpringFactory" />
 		
 	<bean id="lexBigServiceFactory" class="edu.mayo.cts2.framework.plugins.service.LocalClasspathLexBigServiceFactory" />
+
+	<beans profile="noUriResolver">
+		<bean id="restUriResolver" class="edu.mayo.cts2.framework.plugin.service.lexevs.uri.TestRestUriResolver" />
+	</beans>
 	
 </beans>


### PR DESCRIPTION
Upgraded the CTS2 Framework dependency to allow for the correct encoding of Entity names with a colon. Also incremented the version to 1.5.1.FINAL and added support to skip URI Resolver tests if an environment variable is set.