### PR TITLE
Bugfix/lexevscts2 81

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.2.1.FINAL</version>
+		<version>1.2.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
@@ -59,7 +59,7 @@
 	<properties>
 		<forkMode>never</forkMode>
 
-		<lexevs.version>6.4.1.FINAL</lexevs.version>
+		<lexevs.version>6.4.2.FINAL</lexevs.version>
 		<lexevs.remote.version>6.4.1</lexevs.remote.version>
 		<sdk.version>6.4.1</sdk.version>
 		<cagrid.version>1.3</cagrid.version>
@@ -256,8 +256,11 @@
 					<configuration>
 						<enableAssertions>false</enableAssertions>
 						<runOrder>alphabetical</runOrder>
+						<includes>
+							<include>**/*IT.*, **/*Test.java</include>
+						</includes>
 					</configuration>
-
+					
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2.SNAPSHOT.1</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 	<properties>
 		<forkMode>never</forkMode>
 
-		<lexevs.version>6.4.2.FINAL</lexevs.version>
+		<lexevs.version>6.4.2.SNAPSHOT.1</lexevs.version>
 		<lexevs.remote.version>6.4.1</lexevs.remote.version>
 		<sdk.version>6.4.1</sdk.version>
 		<cagrid.version>1.3</cagrid.version>

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/resolvedvalueset/LexEvsResolvedValueSetResolutionService.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/resolvedvalueset/LexEvsResolvedValueSetResolutionService.java
@@ -20,6 +20,7 @@ import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeVersionOrTag;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.codingSchemes.CodingScheme;
+import org.apache.commons.lang.NotImplementedException;
 import org.springframework.stereotype.Component;
 
 import edu.mayo.cts2.framework.core.url.UrlConstructor;
@@ -34,12 +35,14 @@ import edu.mayo.cts2.framework.model.core.URIAndEntityName;
 import edu.mayo.cts2.framework.model.core.MatchAlgorithmReference;
 import edu.mayo.cts2.framework.model.core.PredicateReference;
 import edu.mayo.cts2.framework.model.core.ComponentReference;
+import edu.mayo.cts2.framework.model.core.EntityReferenceList;
 import edu.mayo.cts2.framework.model.core.SortCriteria;
 import edu.mayo.cts2.framework.model.directory.DirectoryResult;
 import edu.mayo.cts2.framework.model.entity.EntityDescription;
 import edu.mayo.cts2.framework.model.entity.EntityDirectoryEntry;
 import edu.mayo.cts2.framework.model.entity.EntityListEntry;
 import edu.mayo.cts2.framework.model.service.core.DocumentedNamespaceReference;
+import edu.mayo.cts2.framework.model.service.core.EntityNameOrURI;
 import edu.mayo.cts2.framework.model.service.core.Query;
 import edu.mayo.cts2.framework.model.util.ModelUtils;
 import edu.mayo.cts2.framework.model.valuesetdefinition.ResolvedValueSet;
@@ -321,6 +324,11 @@ ResolvedValueSetResolutionService {
 				return entityRestrictions;
 			}
 		};
+	}
+
+	@Override
+	public EntityReferenceList contains(ResolvedValueSetReadId identifier, Set<EntityNameOrURI> entities) {
+		throw new NotImplementedException("The contains method has not been implemented");
 	}
 	
 }

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/valuesetdefinition/LexEvsValueSetDefinitionResolutionService.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/valuesetdefinition/LexEvsValueSetDefinitionResolutionService.java
@@ -22,10 +22,12 @@ import edu.mayo.cts2.framework.model.command.ResolvedReadContext;
 import edu.mayo.cts2.framework.model.core.MatchAlgorithmReference;
 import edu.mayo.cts2.framework.model.core.PredicateReference;
 import edu.mayo.cts2.framework.model.core.ComponentReference;
+import edu.mayo.cts2.framework.model.core.EntityReferenceList;
 import edu.mayo.cts2.framework.model.core.SortCriteria;
 import edu.mayo.cts2.framework.model.core.URIAndEntityName;
 import edu.mayo.cts2.framework.model.entity.EntityDirectoryEntry;
 import edu.mayo.cts2.framework.model.service.core.DocumentedNamespaceReference;
+import edu.mayo.cts2.framework.model.service.core.EntityNameOrURI;
 import edu.mayo.cts2.framework.model.service.core.NameOrURI;
 import edu.mayo.cts2.framework.model.util.ModelUtils;
 import edu.mayo.cts2.framework.model.valuesetdefinition.ResolvedValueSet;
@@ -171,6 +173,12 @@ public class LexEvsValueSetDefinitionResolutionService extends AbstractLexEvsSer
 			//Invalid name - return null;
 			return null;
 		}
+	}
+
+	@Override
+	public EntityReferenceList contains(ValueSetDefinitionReadId definitionId, Set<EntityNameOrURI> entities) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 	
 }


### PR DESCRIPTION
Updating POM to point to Java 8 compliant dependencies in LexEVS and the CTS2 Framework