### PR TITLE
LEXEVSCTS2-1111 Release the ResolvedConceptReferencesIterator it is done

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.2.1.FINAL</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.5.1.1.FINAL</version>
+	<version>1.5.2-SNAPSHOT</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>
@@ -59,7 +59,7 @@
 	<properties>
 		<forkMode>never</forkMode>
 
-		<lexevs.version>6.4.1.1.FINAL</lexevs.version>
+		<lexevs.version>6.4.2.SNAPSHOT.1</lexevs.version>
 		<lexevs.remote.version>6.4.1</lexevs.remote.version>
 		<sdk.version>6.4.1</sdk.version>
 		<cagrid.version>1.3</cagrid.version>
@@ -256,6 +256,9 @@
 					<configuration>
 						<enableAssertions>false</enableAssertions>
 						<runOrder>alphabetical</runOrder>
+						<includes>
+							<include>**/*IT.*, **/*Test.java</include>
+						</includes>
 					</configuration>
 
 				</plugin>
@@ -716,6 +719,7 @@
 			<version>2.5</version>
 			<scope>provided</scope>
 		</dependency>
+		
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/resolvedvalueset/LexEvsResolvedValueSetResolutionService.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/resolvedvalueset/LexEvsResolvedValueSetResolutionService.java
@@ -34,12 +34,14 @@ import edu.mayo.cts2.framework.model.core.URIAndEntityName;
 import edu.mayo.cts2.framework.model.core.MatchAlgorithmReference;
 import edu.mayo.cts2.framework.model.core.PredicateReference;
 import edu.mayo.cts2.framework.model.core.ComponentReference;
+import edu.mayo.cts2.framework.model.core.EntityReferenceList;
 import edu.mayo.cts2.framework.model.core.SortCriteria;
 import edu.mayo.cts2.framework.model.directory.DirectoryResult;
 import edu.mayo.cts2.framework.model.entity.EntityDescription;
 import edu.mayo.cts2.framework.model.entity.EntityDirectoryEntry;
 import edu.mayo.cts2.framework.model.entity.EntityListEntry;
 import edu.mayo.cts2.framework.model.service.core.DocumentedNamespaceReference;
+import edu.mayo.cts2.framework.model.service.core.EntityNameOrURI;
 import edu.mayo.cts2.framework.model.service.core.Query;
 import edu.mayo.cts2.framework.model.util.ModelUtils;
 import edu.mayo.cts2.framework.model.valuesetdefinition.ResolvedValueSet;
@@ -60,6 +62,7 @@ import edu.mayo.cts2.framework.service.profile.resolvedvalueset.ResolvedValueSet
 import edu.mayo.cts2.framework.service.profile.resolvedvalueset.name.ResolvedValueSetReadId;
 import edu.mayo.cts2.framework.service.profile.valuesetdefinition.ResolvedValueSetResolutionEntityQuery;
 import edu.mayo.cts2.framework.service.profile.valuesetdefinition.ResolvedValueSetResult;
+import edu.stanford.smi.protegex.owl.swrl.bridge.exceptions.NotImplementedException;
 
 @Component
 public class LexEvsResolvedValueSetResolutionService extends AbstractLexEvsService implements
@@ -323,4 +326,8 @@ ResolvedValueSetResolutionService {
 		};
 	}
 	
+	@Override
+	public EntityReferenceList contains(ResolvedValueSetReadId identifier, Set<EntityNameOrURI> entities) {
+		return null;
+	}
 }

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/valuesetdefinition/LexEvsValueSetDefinitionResolutionService.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/service/valuesetdefinition/LexEvsValueSetDefinitionResolutionService.java
@@ -22,10 +22,12 @@ import edu.mayo.cts2.framework.model.command.ResolvedReadContext;
 import edu.mayo.cts2.framework.model.core.MatchAlgorithmReference;
 import edu.mayo.cts2.framework.model.core.PredicateReference;
 import edu.mayo.cts2.framework.model.core.ComponentReference;
+import edu.mayo.cts2.framework.model.core.EntityReferenceList;
 import edu.mayo.cts2.framework.model.core.SortCriteria;
 import edu.mayo.cts2.framework.model.core.URIAndEntityName;
 import edu.mayo.cts2.framework.model.entity.EntityDirectoryEntry;
 import edu.mayo.cts2.framework.model.service.core.DocumentedNamespaceReference;
+import edu.mayo.cts2.framework.model.service.core.EntityNameOrURI;
 import edu.mayo.cts2.framework.model.service.core.NameOrURI;
 import edu.mayo.cts2.framework.model.util.ModelUtils;
 import edu.mayo.cts2.framework.model.valuesetdefinition.ResolvedValueSet;
@@ -171,6 +173,12 @@ public class LexEvsValueSetDefinitionResolutionService extends AbstractLexEvsSer
 			//Invalid name - return null;
 			return null;
 		}
+	}
+	
+	@Override
+	public EntityReferenceList contains(ValueSetDefinitionReadId definitionId, Set<EntityNameOrURI> entities) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 	
 }

--- a/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/utility/CommonUtils.java
+++ b/src/main/java/edu/mayo/cts2/framework/plugin/service/lexevs/utility/CommonUtils.java
@@ -61,11 +61,13 @@ public final class CommonUtils {
 			nameConverter.getCodingSchemeNameTranslator().translateToLexGrid(entityName.getNamespace()), 
 			codingSchemeName.getName());
 		
+		ResolvedConceptReferencesIterator lexResolvedConceptReferencesIterator = null;
+		
 		try {
 			lexCodedNodeSet = lexBigService.getNodeSet(codingSchemeName.getName(), versionOrTag, null);
 			lexCodedNodeSet = lexCodedNodeSet.restrictToCodes(referenceList);
 			
-			ResolvedConceptReferencesIterator lexResolvedConceptReferencesIterator = lexCodedNodeSet.resolve(null, null, null);
+			lexResolvedConceptReferencesIterator = lexCodedNodeSet.resolve(null, null, null);
 			
 			if(! lexResolvedConceptReferencesIterator.hasNext()){
 				return null;
@@ -74,7 +76,15 @@ public final class CommonUtils {
 			}
 		} catch (LBException e) {
 			throw new RuntimeException(e);
-		}
+		} finally {
+			if(lexResolvedConceptReferencesIterator != null) {
+				try {
+					lexResolvedConceptReferencesIterator.release();
+				}catch (LBException e) {
+					throw new RuntimeException(e);
+				}
+			}
+ 		}
 		
 	}
 


### PR DESCRIPTION
LEXEVSCTS2-1111 Release the ResolvedConceptReferencesIterator it is done being used. 
Update CTS2 framework to 1.3.0-SNAPSHOT. 
Update lexevs-service to 1.5.2-SNAPSHOT. 
Update lexevs version to 6.4.2.SNAPSHOT.1