### PR TITLE
Bugfix/lexevscts2 174  exclude packaging the SLF4J jars 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.6.0.RC.1</version>
+	<version>1.6.0.RC.2</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,8 @@
 						WEB-INF/lib/axis-saaj*.jar,
 						WEB-INF/lib/xercesImpl*.jar,
 						WEB-INF/lib/commons-codec-1.2.jar,
+						WEB-INF/lib/slf4j-api-1.5.8.jar,
+						WEB-INF/lib/slf4j-log4j12-1.5.8.jar
 					</packagingExcludes>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Bugfix/lexevscts2 174  exclude packaging the SLF4J jars 