### PR TITLE
LEXEVSCTS2-235 - Updated pom to pull cts2 framework version 1.6.5.FINAL (updated wsdls to https)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.3.4.FINAL</version>
+		<version>1.3.5.FINAL</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.6.1.SNAPSHOT.1</version>
+	<version>1.6.1.SNAPSHOT.2</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>


### PR DESCRIPTION
LEXEVSCTS2-235 - Updated pom to pull cts2 framework version 1.6.5.FINAL (updated wsdls to https)