### PR TITLE
LEXEVSCTS2-237 Updated CTS2 version to 1.3.3.1.FINAL and lexevs-service to 1.6.0.1.FINAL for WSDL changes from http to https.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.3.3.FINAL</version>
+		<version>1.3.3.1.FINAL</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.6.0.FINAL</version>
+	<version>1.6.0.1.FINAL</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>


### PR DESCRIPTION
LEXEVSCTS2-237 Updated CTS2 version to 1.3.3.1.FINAL and lexevs-service to 1.6.0.1.FINAL for WSDL changes from http to https.