### PR TITLE
LEXEVSCTS2-243 Updated pom to point to CTS2 Framework 1.3.6.RC2 with local XSDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>edu.mayo.cts2.framework</groupId>
 		<artifactId>cts2-base-service-plugin</artifactId>
-		<version>1.3.6.RC1</version>
+		<version>1.3.6.RC2</version>
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.6.1.SNAPSHOT.2</version>
+	<version>1.6.1.SNAPSHOT.3</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>


### PR DESCRIPTION
LEXEVSCTS2-243 Updated pom to point to CTS2 Framework 1.3.6.RC2 with local XSDs