### PR TITLE
Bugfix/lexevscts2 329 - updated version to 1.6.2.RC.4 and lexevs version to 6.5.2.RC.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.6.2.RC.3</version>
+	<version>1.6.2.RC.4</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>
@@ -59,7 +59,7 @@
 	<properties>
 		<forkCount>4</forkCount>
         <reuseForks>false</reuseForks>
-		<lexevs.version>6.5.2.RC.3</lexevs.version>
+		<lexevs.version>6.5.2.RC.4</lexevs.version>
 		<spring-security.version>${org.springframework-version}</spring-security.version>
 	</properties>
 


### PR DESCRIPTION
Bugfix/lexevscts2 329 - updated version to 1.6.2.RC.4 and lexevs version to 6.5.2.RC.4