### PR TITLE
LEXEVSCTS2-363 Updated POM file to point to the 6.5.2 final version of LexEVS and the 1.6.2 final version of lexevs-service.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>1.6.2.RC.6</version>
+	<version>1.6.2.FINAL</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>
@@ -59,7 +59,7 @@
 	<properties>
 		<forkCount>4</forkCount>
         <reuseForks>false</reuseForks>
-		<lexevs.version>6.5.2.RC.6</lexevs.version>
+		<lexevs.version>6.5.2.FINAL</lexevs.version>
 		<spring-security.version>${org.springframework-version}</spring-security.version>
 	</properties>
 


### PR DESCRIPTION
LEXEVSCTS2-363 Updated POM file to point to the 6.5.2 final version of LexEVS and the 1.6.2 final version of lexevs-service.