### PR TITLE
Bugfix/lexevscts2 369  Adjusting an implementation of a LexEVS API to accomodate a new method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>lexevs-service</artifactId>
-	<version>DEV</version>
+	<version>SNAPSHOT.DEV.SPRINT107.2019.05.02</version>
 	<packaging>${packaging}</packaging>
 
 	<description>A CTS2 Framework Service Plugin based on LexEVS</description>

--- a/src/test/java/edu/mayo/cts2/framework/plugins/service/LexBigServiceStub.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugins/service/LexBigServiceStub.java
@@ -21,7 +21,7 @@ import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.SortContext;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Extensions.Generic.GenericExtension;
-import org.LexGrid.LexBIG.Extensions.Generic.LexBIGServiceConvenienceMethods.TerminologyServiceDesignation;
+import org.LexGrid.LexBIG.Extensions.Generic.TerminologyServiceDesignation;
 import org.LexGrid.LexBIG.Extensions.Query.Filter;
 import org.LexGrid.LexBIG.Extensions.Query.Sort;
 import org.LexGrid.LexBIG.History.HistoryService;

--- a/src/test/java/edu/mayo/cts2/framework/plugins/service/LexBigServiceStub.java
+++ b/src/test/java/edu/mayo/cts2/framework/plugins/service/LexBigServiceStub.java
@@ -21,6 +21,7 @@ import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.SortContext;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Extensions.Generic.GenericExtension;
+import org.LexGrid.LexBIG.Extensions.Generic.LexBIGServiceConvenienceMethods.TerminologyServiceDesignation;
 import org.LexGrid.LexBIG.Extensions.Query.Filter;
 import org.LexGrid.LexBIG.Extensions.Query.Sort;
 import org.LexGrid.LexBIG.History.HistoryService;
@@ -182,6 +183,12 @@ public class LexBigServiceStub implements LexBIGService{
 
 	@Override
 	public String getLexEVSBuildTimestamp() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public TerminologyServiceDesignation getTerminologyServiceObjectType(String uri) {
 		// TODO Auto-generated method stub
 		return null;
 	}


### PR DESCRIPTION
This implementation does not have a code use in CTS2 at this time.  However, we were required to update  to keep the implementation current.  